### PR TITLE
fix: scenario with a constraint without variables in python 3.

### DIFF
--- a/constraint/__init__.py
+++ b/constraint/__init__.py
@@ -281,7 +281,7 @@ class Problem(object):
         constraints = []
         for constraint, variables in self._constraints:
             if not variables:
-                variables = allvariables
+                variables = list(allvariables)
             constraints.append((constraint, variables))
         vconstraints = {}
         for variable in domains:

--- a/tests/test_constraint.py
+++ b/tests/test_constraint.py
@@ -79,5 +79,13 @@ def test_studentdesks():
     assert solutions == expected_solutions
 
 
+def test_constraint_without_variables():
+    problem = constraint.Problem()
+    problem.addVariable("a", [1, 2, 3])
+    problem.addConstraint(lambda a: a * 2 == 6)
+    solutions = problem.getSolutions()
+    assert solutions == [{'a': 3}]
+
+
 def test_version():
     assert isinstance(constraint.__version__, compat.string_types)


### PR DESCRIPTION
In python 3.x, dict.keys() doesn't return an indexable list. Add explicit conversion.