### PR TITLE
Convert `dict_keys` object to list for python3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# PyCharm / Intellij
+.idea/

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/constraint/__init__.py
+++ b/constraint/__init__.py
@@ -688,7 +688,7 @@ class MinConflictsSolver(Solver):
             assignments[variable] = random.choice(domains[variable])
         for _ in xrange(self._steps):
             conflicted = False
-            lst = domains.keys()
+            lst = list(domains.keys())
             random.shuffle(lst)
             for variable in lst:
                 # Check if variable is not in conflict

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -1,0 +1,10 @@
+from constraint import Problem, MinConflictsSolver
+
+
+def test_min_conflicts_solver():
+    problem = Problem(MinConflictsSolver())
+    problem.addVariable("x", [0, 1])
+    problem.addVariable("y", [0, 1])
+    solution = problem.getSolution()
+
+    assert solution == {'x': 0, 'y': 0}

--- a/tests/test_solvers.py
+++ b/tests/test_solvers.py
@@ -7,4 +7,11 @@ def test_min_conflicts_solver():
     problem.addVariable("y", [0, 1])
     solution = problem.getSolution()
 
-    assert solution == {'x': 0, 'y': 0}
+    possible_solutions = [
+        {'x': 0, 'y': 0},
+        {'x': 0, 'y': 1},
+        {'x': 1, 'y': 0},
+        {'x': 1, 'y': 1}
+    ]
+
+    assert solution in possible_solutions


### PR DESCRIPTION
Currently, use of `MinConflictsSolver` results in

```
Traceback (most recent call last):
  File "create_project_groupings.py", line 176, in <module>
    solution = problem.getSolution()
  File "/usr/local/lib/python3.6/site-packages/constraint/__init__.py", line 231, in getSolution
    return self._solver.getSolution(domains, constraints, vconstraints)
  File "/usr/local/lib/python3.6/site-packages/constraint/__init__.py", line 692, in getSolution
    random.shuffle(lst)
  File "/usr/local/Cellar/python/3.6.4_4/Frameworks/Python.framework/Versions/3.6/lib/python3.6/random.py", line 275, in shuffle
    x[i], x[j] = x[j], x[i]
TypeError: 'dict_keys' object does not support indexing
```

This is due to the change in Python 3 to use a special `dict_keys` object instead of a `list`.