### PR TITLE
[Fix #50] Fix support for using a Domain subclass

### DIFF
--- a/constraint/__init__.py
+++ b/constraint/__init__.py
@@ -146,10 +146,10 @@ class Problem(object):
         if variable in self._variables:
             msg = "Tried to insert duplicated variable %s" % repr(variable)
             raise ValueError(msg)
-        if hasattr(domain, "__getitem__"):
+        if isinstance(domain, Domain):
+            domain = copy.deepcopy(domain)
+        elif hasattr(domain, "__getitem__"):
             domain = Domain(domain)
-        elif isinstance(domain, Domain):
-            domain = copy.copy(domain)
         else:
             msg = "Domains must be instances of subclasses of the Domain class"
             raise TypeError(msg)

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -1,0 +1,28 @@
+from constraint import Constraint, Domain, Problem
+
+
+def test_addVariable_support_domain_subclasses():
+    class MyCustomDomain(Domain):
+        pass
+
+    class MyConstraint(Constraint):
+        def __call__(self, variables, domains,
+                     assignments, forwardcheck=False):
+            assert isinstance(domains['x'], Domain)
+            assert isinstance(domains['y'], MyCustomDomain)
+            return True
+
+    problem = Problem()
+    problem.addVariable("x", [0, 1])
+    problem.addVariable("y", MyCustomDomain([0, 1]))
+    problem.addConstraint(MyConstraint())
+    solution = problem.getSolution()
+
+    possible_solutions = [
+        {"x": 0, "y": 0},
+        {"x": 0, "y": 1},
+        {"x": 1, "y": 0},
+        {"x": 1, "y": 1},
+    ]
+
+    assert solution in possible_solutions


### PR DESCRIPTION
This PR is intended to fix an issue in addVariable(), where any Domain objects passed in the domain parameter were treated as lists rather than being directly used as a Domain.  The main effect of this bug was that it prevented using Domain subclasses, since they were being converted to Domain objects.