### PR TITLE
Do not install tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "python-constraint2" # when set back to "python-constraint", don't forget to remove '2' in other places (e.g. README)
-packages = [{ include = "constraint", from = "." }, { include = "tests" }]
+packages = [{ include = "constraint", from = "." }]
 description = "python-constraint is a module for efficiently solving CSPs (Constraint Solving Problems) over finite domains."
 version = "2.0.0" # adhere to PEP440 versioning: https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#id55
 authors = [


### PR DESCRIPTION
Tests do not belong in a wheel package and definitely not in the site-packages path.

For reference, you can check this PR https://github.com/Lightning-AI/pytorch-lightning/issues/10335.
Also, a nice discussion in StackOverflow [here](https://stackoverflow.com/questions/14454744/does-it-make-sense-to-install-my-python-unit-tests-in-site-packages).