### PR TITLE
Include .so compiled cpython libraries to wheel package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,11 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "python-constraint2" # when set back to "python-constraint", don't forget to remove '2' in other places (e.g. README)
-packages = [{ include = "constraint", from = "." }]
+packages = [
+    { include = "constraint", from = "." },
+    { include = "tests", format = "sdist" }
+]
+include = [{ path = "constraint/*.so", format = "wheel" }]
 description = "python-constraint is a module for efficiently solving CSPs (Constraint Solving Problems) over finite domains."
 version = "2.0.1" # adhere to PEP440 versioning: https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#id55
 authors = [


### PR DESCRIPTION
Apparently, poetry does not include .so files by default when using packages. To solve this, we add an additional include line that ensures the compiled cpython shared libraries are included in the wheel packages.

Before this change, `poetry build -f wheel` produces this wheel package:
![image](https://github.com/user-attachments/assets/56ad8eae-bd38-4ca1-90ad-0994f225ecf6)

And after this change:
![image](https://github.com/user-attachments/assets/740a7438-2d25-4595-940a-d2c9daef8b12)

In addition, tests directory is also included now in the sdist tarball (as proposed [here](https://github.com/python-constraint/python-constraint/pull/85#issuecomment-2622786520))

Fixes: #86 