### PR TITLE
Find module path at runtime

### DIFF
--- a/tests/test_compilation.py
+++ b/tests/test_compilation.py
@@ -3,15 +3,15 @@ from pathlib import Path
 
 def test_if_compiled():
     """Test whether C-extensions are succesfully ran, if enabled."""
-    from constraint import check_if_compiled
+    import constraint
 
     # check if the .so files are commented
-    dir = Path("./constraint")
+    dir = Path(constraint.__file__).resolve().parent
     assert dir.exists()
     files = list(dir.glob("_*.so"))
 
     # check if the code uses C-extensions
     if len(files) > 0:
-        assert check_if_compiled() is False
+        assert constraint.check_if_compiled() is False
     else:
-        assert check_if_compiled()
+        assert constraint.check_if_compiled()


### PR DESCRIPTION
Currently, `test_if_compiled()` only passes if you run the test while being in the source repository. Trying to run the test after installing the generated wheel package in a different directory will fail because "./constraint" may not exist, or worse, give a false failure since the shared libraries might exist in the wheel package but not in the source directory.

Instead, let's get the get the path of `constraint` at runtime so that the test can be run in both scenarios.

(I'm not sure if this will work as-it-is with current GitHub Actions, so opening this PR to figure it out)